### PR TITLE
Made the command to generate a SECRET_KEY_BASE more portable

### DIFF
--- a/docs/manual/server/self-hosting/quick-start.md
+++ b/docs/manual/server/self-hosting/quick-start.md
@@ -120,7 +120,7 @@ user sessions (amongst other things). You can generate one with the following
 command:
 
 ```sh
-tr -dc A-Za-z0-9 </dev/urandom | head -c 64; echo
+LC_CTYPE=C tr -dc "[:alnum:]" </dev/urandom | head -c 64; echo
 ```
 
 The `URL_SCHEME`, `URL_HOST` and `URL_PORT` variables configure the root URL


### PR DESCRIPTION
macOS treats input files to tr as UTF-8 by default and the chances of /dev/random spitting out valid UTF-8 is low (which causes tr to fail and output nothing). Also, the complement of "A-Za-z0-9" seems to allow for invalid characters for some reason, but the alnum character class doesn't.