### PR TITLE
docs/manual/asciicast/v2: UNIX timestamp to be real

### DIFF
--- a/docs/manual/asciicast/v2.md
+++ b/docs/manual/asciicast/v2.md
@@ -42,7 +42,8 @@ Initial terminal height, i.e. number of rows. Integer.
 
 #### `timestamp`
 
-Unix timestamp of the beginning of the recording session. Integer.
+[Unix timestamp](https://en.wikipedia.org/wiki/Unix_time)
+of the beginning of the recording session. Integer or float.
 
 #### `duration`
 


### PR DESCRIPTION
The optional header in the timestamp is documented in the docs as being an integer only ; Asciinema doesn't care about the header timestamp, but the header check code tolerates int and float. so it shouldn't be much of a problem...

I'm using the asciicast v2 file format in [CapTTY](https://gitlab.com/exmakhina/captty/), a tool to perform stream captures, as an alternative to binary capture formats ; having a ratification that the header field is a real would simplify things.