### PR TITLE
Add asciinema-scripted to the list of integrations

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -18,6 +18,7 @@ of cool things out there (in alphabetical order):
 - [asciinema-player-vue](https://github.com/xuchangjunjx/asciinema-player-vue) - Vue.js integration for asciinema-player
 - [asciinema-scenario](https://github.com/garbas/asciinema-scenario) - Create asciinema videos from a text file
 - [asciinema-scene](https://github.com/jdum/asciinema-scene) - Toolbox to edit asciinema screencasts
+- [asciinema-scripted](https://github.com/robmoss/asciinema-scripted) - Generate scripted asciinema recordings
 - [asciinema-trim](https://github.com/suzuki-shunsuke/asciinema-trim) - Trim and change the playback speed of asciinema's session
 - [asciinema-vsync](https://github.com/JakeWharton/asciinema-vsync) - Batch the commands inside an asciinema JSON file to reduce flickering
 - [AsciinemaGenerator.jl](https://github.com/GiggleLiu/AsciinemaGenerator.jl) - Generate asciinema `.cast` file from a Julia script


### PR DESCRIPTION
I've been using `asciinema` to record terminal sessions for online training materials since early last year (here's [one example](https://git-is-my-lab-book.net/guides/using-git/choosing-your-git-editor/)). The ability to record and play back these sessions (and to pause the recording and copy text) is fantastic. Thank you very much!

For longer, more complex examples, I wanted the ability to script the input and automatically insert markers and comments, so I've written a relatively simple Python package called `asciinema-scripted`.

This PR adds [asciinema-scripted](https://github.com/robmoss/asciinema-scripted) to the Integrations page.

This` tool allows you to record scripted terminal sessions, and provides the following features:

* Terminal input is predefined, so that you can avoid typing mistakes (similar to [autorecorder](https://github.com/NorfairKing/autorecorder));

* Input speed can be controlled, so that viewers can easily follow the input;

* Input delays can be sampled at random, to mimic human typing;

* [Markers](https://docs.asciinema.org/manual/player/markers/) are defined relative to input events, so their times are calculated automatically;

* Comments can be displayed in a "subtitle" bar at the top or bottom of the terminal — a feature introduced by [asciinema-comment](https://github.com/hydrargyrum/asciinema-comment).