### PR TITLE
Keyboard Shortcuts page: Add Markers and fix config sections

### DIFF
--- a/docs/manual/cli/shortcuts.md
+++ b/docs/manual/cli/shortcuts.md
@@ -31,8 +31,7 @@ shortcut | action | 3.x config file option | 2.x config file option | notes
 
 ## Prefix key
 
-You can define a "prefix key" for the recording shortcuts with `rec.prefix_key`
-option in the config file:
+You can define a "prefix key" for the recording shortcuts in the [config file](configuration/index.md):
 
 === "CLI 3.0+"
 
@@ -66,7 +65,7 @@ enabled.
 ## Marker shortcut
 
 You can define a shortcut to add [markers](markers.md) during a recording (no default defined).
-For example, to add the `ctrl+x` shortcut:
+For example, to add the `ctrl+x` shortcut to the [config file](configuration/index.md):
 
 === "CLI 3.0+"
 

--- a/docs/manual/cli/shortcuts.md
+++ b/docs/manual/cli/shortcuts.md
@@ -14,7 +14,7 @@ The following keyboard shortcuts are available when recording with `asciinema re
 
 shortcut | action | 3.x config file option | 2.x config file option | notes
 ---------|--------|---------------|------|---
-<kbd>ctrl+\</kbd> | toggle the capture of a terminal | `recording.pause_key` | `rec.pause_key` | similar to "mute" on an audio call
+<kbd>ctrl+\</kbd> | toggle the capture of a terminal | `session.pause_key` | `record.pause_key` | similar to "mute" on an audio call
 <kbd>ctrl+d</kbd> | end the recording session | - | - |  this is handled by a shell
 - | add a [marker](markers.md) | `session.add_marker_key` | `record.add_marker_key` | no default shortcut for this
 

--- a/docs/manual/cli/shortcuts.md
+++ b/docs/manual/cli/shortcuts.md
@@ -16,7 +16,7 @@ shortcut | action | 3.x config file option | 2.x config file option | notes
 ---------|--------|---------------|------|---
 <kbd>ctrl+\</kbd> | toggle the capture of a terminal | `recording.pause_key` | `rec.pause_key` | similar to "mute" on an audio call
 <kbd>ctrl+d</kbd> | end the recording session | - | - |  this is handled by a shell
-- | add a [marker](markers.md) | `recording.add_marker_key` | `rec.add_marker_key` | no default shortcut for this
+- | add a [marker](markers.md) | `session.add_marker_key` | `record.add_marker_key` | no default shortcut for this
 
 ## Playback shortcuts
 

--- a/docs/manual/cli/shortcuts.md
+++ b/docs/manual/cli/shortcuts.md
@@ -37,14 +37,14 @@ option in the config file:
 === "CLI 3.0+"
 
     ```toml title="~/.config/asciinema/config.toml"
-    [recording]
+    [session]
     prefix_key = "C-a"
     ```
 
 === "CLI 2.0+"
 
     ```ini title="~/.config/asciinema/config"
-    [rec]
+    [record]
     prefix_key = C-a
     ```
 

--- a/docs/manual/cli/shortcuts.md
+++ b/docs/manual/cli/shortcuts.md
@@ -62,3 +62,22 @@ enabled.
     2. There's no prefix key concept for the `play` command because there's no
     interactive process to forward the key presses during the playback, and
     therefore no risk of shortcut conflicts.
+
+## Marker shortcut
+
+You can define a shortcut to add [markers](markers.md) during a recording (no default defined).
+For example, to add the `ctrl+x` shortcut:
+
+=== "CLI 3.0+"
+
+    ```toml title="~/.config/asciinema/config.toml"
+    [session]
+    add_marker_key = "^x"
+    ```
+
+=== "CLI 2.0+"
+
+    ```ini title="~/.config/asciinema/config"
+    [record]
+    prefix_key = C-x
+    ```


### PR DESCRIPTION
The [Keyboard Shortcuts](https://docs.asciinema.org/manual/cli/shortcuts) page seems to be using wrong config sections. I am not sure if these used to be valid sections before, or if they were always wrong:

- v3: `recording` -> should be `session`
- v2: `rec` -> should be `record`

This PR fixes these and adds more links to [v3 config](https://docs.asciinema.org/manual/cli/configuration/v2/) and [v2 config](https://docs.asciinema.org/manual/cli/configuration/v3/), where this should be clear.

It also adds a section about defining a Marker key, since there is no default, and since it is unclear how to refer to the `Ctrl` key (different between v2 and v3). Having a working suggestion is also nice.