### PR TITLE
fix typo in Player quick start guide

### DIFF
--- a/docs/manual/player/quick-start.md
+++ b/docs/manual/player/quick-start.md
@@ -108,7 +108,7 @@ and `theme` options like this:
 ```javascript
 AsciinemaPlayer.create('/demo.cast', document.getElementById('demo'), {
   loop: true,
-  theme: 'dracula'
+  theme: 'solarized-dark'
 });
 ```
 


### PR DESCRIPTION
Text says "Solarized Dark" but snippet said `dracula`.